### PR TITLE
Potential fix for code scanning alert no. 5: Incomplete string escaping or encoding

### DIFF
--- a/chrome-extension/src/background/browser/dom/views.ts
+++ b/chrome-extension/src/background/browser/dom/views.ts
@@ -480,8 +480,8 @@ export class DOMElementNode extends DOMBaseNode {
           // Use contains for values with special characters
           // Regex-substitute any whitespace with a single space, then trim
           const collapsedValue = value.replace(/\s+/g, ' ').trim();
-          // Escape embedded double-quotes
-          const safeValue = collapsedValue.replace(/"/g, '\\"');
+          // Escape embedded backslashes and double-quotes
+          const safeValue = collapsedValue.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
           cssSelector += `[${safeAttribute}*="${safeValue}"]`;
         } else {
           cssSelector += `[${safeAttribute}="${value}"]`;


### PR DESCRIPTION
Potential fix for [https://github.com/Patfer-Coding-Company/MexBot/security/code-scanning/5](https://github.com/Patfer-Coding-Company/MexBot/security/code-scanning/5)

To fix the problem, we need to ensure that backslashes in the attribute value are escaped before escaping double quotes. This prevents malformed selectors and injection issues. The best way is to first replace all backslashes (`\`) with double backslashes (`\\`), then escape double quotes as before. This should be done in the same region of code, specifically at line 484 in `chrome-extension/src/background/browser/dom/views.ts`. No new imports are needed, as this can be done with standard JavaScript string methods.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
